### PR TITLE
OGDF library installation with python2 fix

### DIFF
--- a/OGDF/makeMakefile.py
+++ b/OGDF/makeMakefile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # Make Makefile
 #
 # October 2012

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 
 #install OGDF
 cd OGDF
-bash makeMakefile.sh
+./makeMakefile.py
 make -j 16
 cd ..
 


### PR DESCRIPTION
added python2 to shebang for proper installation of OGDF library