### PR TITLE
Enable build on python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# generated files
+OGDF/Makefile
+OGDF/_release/
+OGDF/include/coin/config.h
+OGDF/include/ogdf/internal/config_autogen.h
+OGDF/ogdf.pc
+OGDF/test/test-release
+
+# binaries
+bundler
+libcorrect
+orientcontigs
+spqr

--- a/OGDF/makeMakefile.py
+++ b/OGDF/makeMakefile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 # Make Makefile
 #
 # October 2012
@@ -74,7 +74,7 @@ config = configparser.ConfigParser()
 print('Loading makeMakefile.config...')
 
 try:
-	config.readfp(open('makeMakefile.config'))
+	config.readfp(open('makeMakefile.config'))  # TODO DeprecationWarning: This method will be removed in Python 3.12. Use 'parser.read_file()' instead.
 except IOError:
 	bailout('makeMakefile.config not found')
 
@@ -278,7 +278,7 @@ def Walk(curdir):
 					for v in versions:
 						# print target&depend: add full path spec, incl. version & ignore extra line
 						path = v.call() + '/' +fullname[:-len(name)]
-						makefile.write(path + targetAndDepend[:-1] + '\n')
+						makefile.write(path + targetAndDepend.decode()[:-1] + '\n')
 
 						# ensure folder
 						makefile.write('\t$(MKDIR) ' + v.call() + '/' + fullname[:-len(name)-1] + '\n')

--- a/OGDF/makeMakefile.py
+++ b/OGDF/makeMakefile.py
@@ -74,7 +74,8 @@ config = configparser.ConfigParser()
 print('Loading makeMakefile.config...')
 
 try:
-	config.readfp(open('makeMakefile.config'))  # TODO DeprecationWarning: This method will be removed in Python 3.12. Use 'parser.read_file()' instead.
+	with open('makeMakefile.config') as makefile_config_f:
+		config.read_file(makefile_config_f)
 except IOError:
 	bailout('makeMakefile.config not found')
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -euo pipefail
 
 #install OGDF
 cd OGDF


### PR DESCRIPTION
Python2 has been EOL for a while, but it's pretty easy to get this building on python3.

I also gitignored the generated files and made `install.sh` error/quite early if it encounters an error.